### PR TITLE
Added create_qualitative_cmap function

### DIFF
--- a/cmasher/utils.py
+++ b/cmasher/utils.py
@@ -672,7 +672,7 @@ def get_cmap_type(cmap):
 
 
 # Function create a colormap using a subset of the colors in an existing one
-def get_sub_cmap(cmap, start, stop, segments=None, name=None):
+def get_sub_cmap(cmap, start, stop, N=None, name=None):
     """
     Creates a :obj:`~matplotlib.cm.ListedColormap` object using the colors in
     the range `[start, stop]` of the provided `cmap` and returns it.
@@ -693,7 +693,7 @@ def get_sub_cmap(cmap, start, stop, segments=None, name=None):
 
     Optional
     --------
-    segments : int or None. Default: None
+    N : int or None. Default: None
         The number of color segments to return from the provided `cmap`.
         If *None*, take all colors in `cmap` within the provided `cmap_range`.
 
@@ -712,7 +712,6 @@ def get_sub_cmap(cmap, start, stop, segments=None, name=None):
     Creating a colormap using the first 80% of the 'rainforest' colormap::
 
         >>> get_sub_cmap('cmr.rainforest', 0, 0.8)
-
 
     Creating a qualitative colormap containing 5 colors from the middle 60%
     of the 'lilac' colormap and registering it with the name `cmr.lilac_qual`:
@@ -739,11 +738,11 @@ def get_sub_cmap(cmap, start, stop, segments=None, name=None):
     # Obtain the colormap
     cmap = mplcm.get_cmap(cmap)
 
-    if not (isinstance(segments, int) or (segments is None)):
+    if not (isinstance(N, int) or (N is None)):
         raise ValueError("segments must have type int or None.")
 
     # Obtain colors
-    colors = take_cmap_colors(cmap, segments, cmap_range=(start, stop))
+    colors = take_cmap_colors(cmap, N, cmap_range=(start, stop))
 
     # Check if name has been provided or use default.
     if isinstance(name, str):
@@ -755,7 +754,6 @@ def get_sub_cmap(cmap, start, stop, segments=None, name=None):
 
     # Create new colormap
     sub_cmap = LC(colors, sub_cmap_name, N=len(colors))
-
 
     # Return sub_cmap
     return(sub_cmap)

--- a/cmasher/utils.py
+++ b/cmasher/utils.py
@@ -865,6 +865,58 @@ def import_cmaps(cmap_path):
                              % (cm_name, error))
 
 
+# Function to generate a sequential qualitative colormap from an existing one
+def make_qualitative_cmap(name, cmap, N, cmap_range=(0, 1)):
+    """
+    Creates a qualitative
+
+    Parameters
+    ----------
+    name : str
+        The name that this colormap must have.
+    cmap : str or :obj:`~matplotlib.colors.Colormap` object
+        The registered name of the colormap in :mod:`matplotlib.cm` or its
+        corresponding :obj:`~matplotlib.colors.Colormap` object.
+    N : int or None
+        The number of colors to take from the provided `cmap`.
+        If *None*, take all colors in `cmap` within the provided `cmap_range`.
+
+    Optional
+    --------
+    cmap_range : tuple of float. Default: (0, 1)
+        The normalized value range in the colormap from which colors should be
+        taken.
+        By default, colors are taken from the entire colormap.
+
+    Examples
+    --------
+    Creating a five colour sequential qualitative colormap from rainforest.
+        >>> make_qualitative_cmap('qual_rainforest', cmr.rainforest, 5)
+
+    Creating and using a three color qualitative map with matplotlib
+        >>> import numpy as np
+        >>> import matplotlib.pyplots as plt
+        >>> data = np.array([[0.1, 0.8], [0.3, 0.5]])
+        >>> fig, ax = plt.subplots()
+        >>> make_qualitative_cmap('qual_rainforest', cmr.rainforest, 3)
+        >>> im = ax.imshow(data, cmap=cmr.cm.qual_rainforest)
+        >>> plt.colorbar(im, ax=ax)
+
+    """
+    # Take the qualitative cmap colors from the given cmap
+    colors = take_cmap_colors(cmap, N, cmap_range=cmap_range)
+    # The length of the color in the cmap array.
+    subcolor_len = 256 / N
+
+    # Create new color map from colors
+    qual_cmap = np.empty((256, 3), dtype=float)
+    for i, color in enumerate(colors):
+        qual_cmap[int(i * subcolor_len):int((i + 1) * subcolor_len)] = color
+
+    # Register the new colormap in cmasher and MPL
+    register_cmap(name, qual_cmap)
+
+
 # Function to register a custom colormap in MPL and CMasher
 def register_cmap(name, data):
     """

--- a/cmasher/utils.py
+++ b/cmasher/utils.py
@@ -868,7 +868,9 @@ def import_cmaps(cmap_path):
 # Function to generate a sequential qualitative colormap from an existing one
 def make_qualitative_cmap(name, cmap, N, cmap_range=(0, 1)):
     """
-    Creates a qualitative
+    Creates a qualitative `cmap` of `N` colors from another `cmap` and
+    registers the colormap in the :mod:`cmasher.cm` and :mod:`matplotlib.cm`
+    modules under `name`.
 
     Parameters
     ----------

--- a/cmasher/utils.py
+++ b/cmasher/utils.py
@@ -554,6 +554,60 @@ def create_cmap_overview(cmaps=None, *, savefig=None, use_types=True,
         plt.show()
 
 
+# Function to generate a sequential qualitative colormap from an existing one
+def create_qualitative_cmap(name, cmap, N, cmap_range=(0, 1)):
+    """
+    Creates a qualitative `cmap` of `N` colors from another `cmap` and
+    registers the colormap in the :mod:`cmasher.cm` and :mod:`matplotlib.cm`
+    modules under `name`.
+
+    Parameters
+    ----------
+    name : str
+        The name that this colormap must have.
+    cmap : str or :obj:`~matplotlib.colors.Colormap` object
+        The registered name of the colormap in :mod:`matplotlib.cm` or its
+        corresponding :obj:`~matplotlib.colors.Colormap` object.
+    N : int or None
+        The number of colors to take from the provided `cmap`.
+        If *None*, take all colors in `cmap` within the provided `cmap_range`.
+
+    Optional
+    --------
+    cmap_range : tuple of float. Default: (0, 1)
+        The normalized value range in the colormap from which colors should be
+        taken.
+        By default, colors are taken from the entire colormap.
+
+    Examples
+    --------
+    Creating a five colour sequential qualitative colormap from rainforest.
+        >>> make_qualitative_cmap('qual_rainforest', cmr.rainforest, 5)
+
+    Creating and using a three color qualitative map with matplotlib
+        >>> import numpy as np
+        >>> import matplotlib.pyplots as plt
+        >>> data = np.array([[0.1, 0.8], [0.3, 0.5]])
+        >>> fig, ax = plt.subplots()
+        >>> make_qualitative_cmap('qual_rainforest', cmr.rainforest, 3)
+        >>> im = ax.imshow(data, cmap=cmr.cm.qual_rainforest)
+        >>> plt.colorbar(im, ax=ax)
+
+    """
+    # Take the qualitative cmap colors from the given cmap
+    colors = take_cmap_colors(cmap, N, cmap_range=cmap_range)
+    # The length of the color in the cmap array.
+    subcolor_len = 256 / N
+
+    # Create new color map from colors
+    qual_cmap = np.empty((256, 3), dtype=float)
+    for i, color in enumerate(colors):
+        qual_cmap[int(i * subcolor_len):int((i + 1) * subcolor_len)] = color
+
+    # Register the new colormap in cmasher and MPL
+    register_cmap(name, qual_cmap)
+
+
 # Define function that prints a string with the BibTeX entry to CMasher's paper
 def get_bibtex():
     """
@@ -863,60 +917,6 @@ def import_cmaps(cmap_path):
         except Exception as error:
             raise ValueError("Provided colormap %r is invalid! (%s)"
                              % (cm_name, error))
-
-
-# Function to generate a sequential qualitative colormap from an existing one
-def make_qualitative_cmap(name, cmap, N, cmap_range=(0, 1)):
-    """
-    Creates a qualitative `cmap` of `N` colors from another `cmap` and
-    registers the colormap in the :mod:`cmasher.cm` and :mod:`matplotlib.cm`
-    modules under `name`.
-
-    Parameters
-    ----------
-    name : str
-        The name that this colormap must have.
-    cmap : str or :obj:`~matplotlib.colors.Colormap` object
-        The registered name of the colormap in :mod:`matplotlib.cm` or its
-        corresponding :obj:`~matplotlib.colors.Colormap` object.
-    N : int or None
-        The number of colors to take from the provided `cmap`.
-        If *None*, take all colors in `cmap` within the provided `cmap_range`.
-
-    Optional
-    --------
-    cmap_range : tuple of float. Default: (0, 1)
-        The normalized value range in the colormap from which colors should be
-        taken.
-        By default, colors are taken from the entire colormap.
-
-    Examples
-    --------
-    Creating a five colour sequential qualitative colormap from rainforest.
-        >>> make_qualitative_cmap('qual_rainforest', cmr.rainforest, 5)
-
-    Creating and using a three color qualitative map with matplotlib
-        >>> import numpy as np
-        >>> import matplotlib.pyplots as plt
-        >>> data = np.array([[0.1, 0.8], [0.3, 0.5]])
-        >>> fig, ax = plt.subplots()
-        >>> make_qualitative_cmap('qual_rainforest', cmr.rainforest, 3)
-        >>> im = ax.imshow(data, cmap=cmr.cm.qual_rainforest)
-        >>> plt.colorbar(im, ax=ax)
-
-    """
-    # Take the qualitative cmap colors from the given cmap
-    colors = take_cmap_colors(cmap, N, cmap_range=cmap_range)
-    # The length of the color in the cmap array.
-    subcolor_len = 256 / N
-
-    # Create new color map from colors
-    qual_cmap = np.empty((256, 3), dtype=float)
-    for i, color in enumerate(colors):
-        qual_cmap[int(i * subcolor_len):int((i + 1) * subcolor_len)] = color
-
-    # Register the new colormap in cmasher and MPL
-    register_cmap(name, qual_cmap)
 
 
 # Function to register a custom colormap in MPL and CMasher

--- a/cmasher/utils.py
+++ b/cmasher/utils.py
@@ -672,7 +672,7 @@ def get_cmap_type(cmap):
 
 
 # Function create a colormap using a subset of the colors in an existing one
-def get_sub_cmap(cmap, start, stop, N=None, name=None):
+def get_sub_cmap(cmap, start, stop, N=None):
     """
     Creates a :obj:`~matplotlib.cm.ListedColormap` object using the colors in
     the range `[start, stop]` of the provided `cmap` and returns it.
@@ -697,11 +697,6 @@ def get_sub_cmap(cmap, start, stop, N=None, name=None):
         The number of color segments to return from the provided `cmap`.
         If *None*, take all colors in `cmap` within the provided `cmap_range`.
 
-    name : str or None. Default: None
-        Creates a :obj:`~matplotlib.colors.ListedColormap` object using the
-        provided `name`.
-        By default, the cmap will be registered with cmap.name + "_sub".
-
     Returns
     -------
     sub_cmap : :obj:`~matplotlib.colors.ListedColormap`
@@ -714,9 +709,9 @@ def get_sub_cmap(cmap, start, stop, N=None, name=None):
         >>> get_sub_cmap('cmr.rainforest', 0, 0.8)
 
     Creating a qualitative colormap containing 5 colors from the middle 60%
-    of the 'lilac' colormap and registering it with the name `cmr.lilac_qual`:
+    of the 'lilac' colormap:
 
-        >>> get_subcmap('cmr.lilac', 0.2, 0.8, segments=5, name="lilac_qual")
+        >>> get_subcmap('cmr.lilac', 0.2, 0.8, N=5)
 
     Notes
     -----
@@ -739,21 +734,13 @@ def get_sub_cmap(cmap, start, stop, N=None, name=None):
     cmap = mplcm.get_cmap(cmap)
 
     if not (isinstance(N, int) or (N is None)):
-        raise ValueError("segments must have type int or None.")
+        raise ValueError("N must have type int or None.")
 
     # Obtain colors
     colors = take_cmap_colors(cmap, N, cmap_range=(start, stop))
 
-    # Check if name has been provided or use default.
-    if isinstance(name, str):
-        sub_cmap_name = name
-    elif name is not None:
-        raise ValueError("name must have have type str or None.")
-    else:
-        sub_cmap_name = cmap.name + '_sub'
-
     # Create new colormap
-    sub_cmap = LC(colors, sub_cmap_name, N=len(colors))
+    sub_cmap = LC(colors, cmap_name + '_sub', N=len(colors))
 
     # Return sub_cmap
     return(sub_cmap)


### PR DESCRIPTION
I have written a fairly simple function to turn any colormap into a qualitative one (i.e a single colour between two values).

I haven't written any tests for it, but I have run pytest on my computer and it doesn't seem to break anything (and passes flake8.

Let me know if there is anything I should change or fix before you can merge it. I wasn't sure about the naming style you would prefer for this function. I went with 'create', but I think 'make' or 'generate' would also work.