### PR TITLE
Tighten up flake8 tests

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -12,7 +12,7 @@ jobs:
       - run: codespell --ignore-words-list="mutch"
       - run: flake8 . --count --max-complexity=39 --max-line-length=88 --show-source --statistics
       - run: isort --check-only --profile black . || true
-      - run: pip install -r requirements.txt || true
+      - run: pip install -r requirements.txt
       - run: mypy --ignore-missing-imports . || true
       - run: pytest . || true
       - run: pytest --doctest-modules . || true

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -10,8 +10,7 @@ jobs:
       - run: bandit --recursive --skip B101 .  # B101 is assert statements
       - run: black --check . || true
       - run: codespell --ignore-words-list="mutch"
-      - run: flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-      - run: flake8 . --count --exit-zero --max-complexity=10 --max-line-length=88 --show-source --statistics
+      - run: flake8 . --count --max-complexity=39 --max-line-length=88 --show-source --statistics
       - run: isort --check-only --profile black . || true
       - run: pip install -r requirements.txt || true
       - run: mypy --ignore-missing-imports . || true

--- a/cmasher/__init__.py
+++ b/cmasher/__init__.py
@@ -7,6 +7,7 @@ Scientific colormaps for making accessible, informative and *cmashing* plots.
 
 """
 
+# flake8: noqa
 
 # %% IMPORTS AND DECLARATIONS
 # CMasher imports

--- a/cmasher/tests/test_utils.py
+++ b/cmasher/tests/test_utils.py
@@ -7,7 +7,6 @@ import os
 from os import path
 
 # Package imports
-import cmocean as cmo
 import matplotlib.pyplot as plt
 from matplotlib import cm as mplcm
 from matplotlib.colors import ListedColormap as LC

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,12 +4,6 @@ universal = 0
 [tool:pytest]
 addopts = --mpl --flake8 -v --cov --cov-config=setup.cfg --cov-report=term-missing
 testpaths = ./cmasher
-flake8-ignore =
-  E226
-  F401
-  F403
-  W503
-  W504
 
 [coverage:run]
 include = cmasher/*


### PR DESCRIPTION
Make the flake8 tests stricter and ignore flake8 testing in the init file to bypass unused imports and wildcard imports.