### PR TITLE
MNT: drop support for EOL Python versions 3.6 and 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,9 @@ jobs:
       matrix:
         architecture: [x86, x64]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version:
+          - "3.8"
+          - "3.9"
         exclude:
           - os: ubuntu-latest
             architecture: x86

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,8 +19,6 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering :: Visualization",
@@ -29,7 +27,7 @@ classifiers = [
 ]
 keywords = ["cmasher perceptually uniform sequential colormaps plotting python visualization"]
 
-requires-python = ">=3.6, <4"
+requires-python = ">=3.8, <4"
 
 # keep in sync with requirements.txt
 dependencies = [


### PR DESCRIPTION
I will also add explicit support for Python 3.10 to 3.12 in another PR, after I'm done reviving CI.