### PR TITLE
MNT: temporarily deactivate cross-plateform CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,17 +11,22 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        architecture: [x86, x64]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        architecture:
+          #- x86
+          - x64
+        os:
+          - ubuntu-latest
+          #- macos-latest
+          #- windows-latest
         python-version:
-          - "3.8"
+          #- "3.8"
           - "3.9"
-        exclude:
-          - os: ubuntu-latest
-            architecture: x86
-          - os: macos-latest
-            architecture: x86
-      fail-fast: false
+        #exclude:
+        #  - os: ubuntu-latest
+        #    architecture: x86
+        #  - os: macos-latest
+        #    architecture: x86
+      fail-fast: true # tmp
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
this is a temporary measure to stop the bleeding so I can focus on fixing CI one job at a time