### PR TITLE
MNT: drop support for Python 3.8

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,6 @@ jobs:
           #- macos-latest
           #- windows-latest
         python-version:
-          #- "3.8"
         - '3.9'
         #exclude:
         #  - os: ubuntu-latest

--- a/cmasher/cm.py
+++ b/cmasher/cm.py
@@ -8,7 +8,6 @@ Holds all the different colormaps that are in *CMasher*.
 
 # %% IMPORTS
 # Built-in imports
-from typing import Dict
 
 # Package imports
 from matplotlib.colors import ListedColormap as LC
@@ -19,11 +18,11 @@ __all__ = []
 
 # %% GLOBALS
 # Type aliases
-CMAP_DCT = Dict[str, LC]
+CMAP_DCT = dict[str, LC]
 
 # Initialize empty dict to hold colormaps in
 cmap_d: CMAP_DCT = {}
-cmap_cd: Dict[str, CMAP_DCT] = {
+cmap_cd: dict[str, CMAP_DCT] = {
     "sequential": {},
     "diverging": {},
     "cyclic": {},

--- a/cmasher/utils.py
+++ b/cmasher/utils.py
@@ -10,10 +10,11 @@ Utility functions for registering and manipulating colormaps in various ways.
 # Built-in imports
 import warnings
 from collections import OrderedDict as odict
+from collections.abc import Iterable
 from glob import glob
 from os import path
 from textwrap import dedent
-from typing import Callable, Iterable, List, Optional, Tuple, Union
+from typing import Callable, Optional, Union
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -84,7 +85,7 @@ class _HandlerColorPolyCollection(HandlerBase):
 
 # %% HELPER FUNCTIONS
 # Define function for obtaining the sorting order for lightness ranking
-def _get_cmap_lightness_rank(cmap: CMAP) -> Tuple[int, int, float, float, float, str]:
+def _get_cmap_lightness_rank(cmap: CMAP) -> tuple[int, int, float, float, float, str]:
     """
     Returns a tuple of objects used for sorting the provided `cmap` based
     on its lightness profile.
@@ -188,7 +189,7 @@ def _get_cmap_lightness_rank(cmap: CMAP) -> Tuple[int, int, float, float, float,
 # Define function for obtaining the sorting order for perceptual ranking
 def _get_cmap_perceptual_rank(
     cmap: CMAP
-) -> Tuple[int, int, float, float, float, float, str]:
+) -> tuple[int, int, float, float, float, float, str]:
     """
     In addition to returning the lightness rank as given by
     :func:`~_get_cmap_lightness_rank`, also returns the length of the
@@ -391,7 +392,7 @@ def create_cmap_mod(
 
 # This function creates an overview plot of all colormaps specified
 def create_cmap_overview(
-    cmaps: Optional[List[CMAP]] = None,
+    cmaps: Optional[list[CMAP]] = None,
     *,
     savefig: Optional[str] = None,
     use_types: bool = True,
@@ -864,7 +865,7 @@ def get_bibtex() -> None:
 
 
 # This function returns a list of all colormaps available in CMasher
-def get_cmap_list(cmap_type: str = "all") -> List[str]:
+def get_cmap_list(cmap_type: str = "all") -> list[str]:
     """
     Returns a list with the names of all colormaps available in *CMasher* of
     the given `cmap_type`.
@@ -1324,7 +1325,7 @@ def take_cmap_colors(
     cmap: CMAP,
     N: Optional[int],
     *,
-    cmap_range: Tuple[float, float] = (0, 1),
+    cmap_range: tuple[float, float] = (0, 1),
     return_fmt: str = "float",
 ) -> RGB:
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,6 @@ classifiers = [
     "Operating System :: Unix",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Topic :: Scientific/Engineering :: Visualization",
     "Topic :: Utilities",
@@ -27,7 +26,7 @@ classifiers = [
 ]
 keywords = ["cmasher perceptually uniform sequential colormaps plotting python visualization"]
 
-requires-python = ">=3.8, <4"
+requires-python = ">=3.9, <4"
 
 # keep in sync with requirements.txt
 dependencies = [


### PR DESCRIPTION
Python 3.8 is borderline "EOL" within scientific Python, so as it is making maintenance more difficult, I'm dropping it.