### PR TITLE
TST: drop support for Windows x86 (32 bits arch)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,13 +7,10 @@ on: [push, pull_request]
 
 jobs:
   build:
-    name: ${{ matrix.os }} ${{ matrix.architecture }}, Python ${{ matrix.python-version }}
+    name: ${{ matrix.os }}, Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        architecture:
-          #- x86
-        - x64
         os:
         - ubuntu-latest
           #- macos-latest
@@ -23,20 +20,14 @@ jobs:
         - '3.10'
         - '3.11'
         - '3.12'
-        #exclude:
-        #  - os: ubuntu-latest
-        #    architecture: x86
-        #  - os: macos-latest
-        #    architecture: x86
       fail-fast: false
 
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }} ${{ matrix.architecture }}
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: ${{ matrix.architecture }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip setuptools wheel


### PR DESCRIPTION
I discovered in https://github.com/1313e/CMasher/actions/runs/7237227888/job/19716623262?pr=84 that the ecosystem is now pretty hostile to this arch so there's not much we can do about it except dropping it.