### PR TITLE
MNT: bump minimal requirement for numpy (1.17.3 -> 1.19.3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ requires-python = ">=3.9, <4"
 dependencies = [
     "colorspacious>=1.1.0",
     "matplotlib>=3.5",
-    "numpy>=1.17.3",
+    "numpy>=1.19.3",
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # keep in sync with pyproject.toml
 colorspacious>=1.1.0
 matplotlib>=3.5
-numpy>=1.17.3
+numpy>=1.19.3


### PR DESCRIPTION
followup to #83