### PR TITLE
TST: detect and avoid test pollution

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,7 @@
 # %% IMPORTS
+# Built-in imports
+import sys
+
 # Package imports
 import matplotlib as mpl
 from py.path import local
@@ -13,6 +16,22 @@ def pytest_report_header(config):
     from cmasher.__version__ import __version__
 
     return "CMasher: %s" % (__version__)
+
+
+def pytest_sessionstart(session):
+    import cmasher
+
+    global AT_START
+    AT_START = set(mpl.colormaps.keys())
+
+
+def pytest_sessionfinish(session, exitstatus):
+    AT_END = set(mpl.colormaps.keys())
+    if diff := (AT_END - AT_START):
+        print(
+            f"The following colormaps appear to have leaked during test session {diff}",
+            file=sys.stderr,
+        )
 
 
 # %% PYTEST SETTINGS

--- a/conftest.py
+++ b/conftest.py
@@ -4,6 +4,7 @@ import sys
 
 # Package imports
 import matplotlib as mpl
+import pytest
 from py.path import local
 
 # Set MPL backend
@@ -37,3 +38,16 @@ def pytest_sessionfinish(session, exitstatus):
 # %% PYTEST SETTINGS
 # Set the current working directory to the temporary directory
 local.get_temproot().chdir()
+
+
+# %% FIXTURES
+@pytest.fixture(scope="function", autouse=True)
+def clean_registration():
+    old = set(mpl.colormaps.keys())
+    yield
+    new = set(mpl.colormaps.keys())
+    for name in new - old:
+        if mpl.__version_info__ >= (3, 6):
+            mpl.colormaps.unregister(name)
+        else:
+            mpl.cm.unregister_cmap(name)


### PR DESCRIPTION
TODO:
- [x] debug job with minimal requirements (maybe a bug in pytest or Matplotlib is compromising my fix ?)
- [ ] cleanup test-only API introduced in #66 (`_skip_registration`)