### PR TITLE
MNT: try to force dependabot to re-index us

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,7 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
 
+
 version: 2
 updates:
 - package-ecosystem: pip


### PR DESCRIPTION
I enabled dependabot auto updates in two months ago in #59. However, since then, we didn't get any pull requests, and I'm seeing warnings that some actions are out of date, so let's try this noop change to force dependabot to notice this repo (this trick was recommended by GitHub support). 