### PR TITLE
TST: revert numpy bump

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,10 +29,16 @@ jobs:
         - '3.10'
         - '3.11'
         - '3.12'
+        with-viscm:
+        - true
+
         include:
         - os: ubuntu-20.04
           python-version: '3.9'
           deps: minimal
+          pip-args: --constraint requirements/min_constraints.txt
+          with-viscm: false
+
       fail-fast: false
 
     concurrency:
@@ -48,12 +54,16 @@ jobs:
 
     - run: |
         python -m pip install --upgrade pip
-        python -m pip install -r requirements/dev.txt
+        python -m pip install -r requirements/dev.txt ${{ matrix.pip-args }}
+
+    - if: matrix.with-viscm
+      run: python -m pip install "viscm>=0.10"
 
     - if: matrix.deps == 'minimal'
       run: |
         pipx run uv pip compile pyproject.toml --resolution=lowest-direct > mindeps.txt
-        python -m pip install --requirement mindeps.txt
+        python -m pip install --requirement mindeps.txt \
+          --only-binary ':all:' ${{ matrix.pip-args }}
 
     - name: Build
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ requires-python = ">=3.9, <4"
 dependencies = [
     "colorspacious>=1.1.0",
     "matplotlib>=3.5",
-    "numpy>=1.23.0",
+    "numpy>=1.19.5",
 ]
 
 [project.urls]

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -2,4 +2,3 @@ pyqt5>=5.12
 pytest>=4.6.0
 pytest-cov
 pytest-mpl
-viscm>=0.10

--- a/requirements/min_constraints.txt
+++ b/requirements/min_constraints.txt
@@ -1,0 +1,2 @@
+scipy<1.11
+contourpy<1.2


### PR DESCRIPTION
in #129, I brutally bumped minimum numpy from 1.19.3 to 1.23.0 . Let's try to roll this back a little.