### PR TITLE
UX: clarify generic error message when failing to import/register a colormap

### DIFF
--- a/src/cmasher/utils.py
+++ b/src/cmasher/utils.py
@@ -1310,9 +1310,7 @@ def import_cmaps(cmap_path: str, *, _skip_registration: bool = False) -> None:
 
         # If any error is raised, reraise it
         except Exception as error:
-            raise ValueError(
-                f"Provided colormap {cm_name} is invalid! ({error})"
-            ) from error
+            raise ValueError(f"Failed to import colormap {cm_name!r}") from error
 
 
 # Function to register a custom colormap in MPL and CMasher


### PR DESCRIPTION
1) stating that the colormap is "invalid" is confusing since there's a lot more than a single failure mode
2) we don't need to re-include the original error message since we're explicitly chaining exceptions already
