### PR TITLE
DOC: Update cmasher/colormaps references

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Colormap overview
 Below is an overview of all the colormaps that are currently in *CMasher* (made with the ``cmr.create_cmap_overview()`` function).
 For more information, see the `online documentation`_.
 
-.. image:: https://github.com/1313e/CMasher/raw/master/cmasher/colormaps/cmap_overview.png
+.. image:: https://github.com/1313e/CMasher/raw/master/src/cmasher/colormaps/cmap_overview.png
     :width: 100%
     :align: center
     :target: https://cmasher.readthedocs.io

--- a/docs/source/user/introduction.rst
+++ b/docs/source/user/introduction.rst
@@ -88,4 +88,4 @@ See :ref:`usage` for more use-cases, including an overview of *CMasher*'s utilit
 .. _conda-forge: https://anaconda.org/conda-forge/CMasher
 .. _matplotlib: https://github.com/matplotlib/matplotlib
 .. _issue: https://github.com/1313e/CMasher/issues
-.. _cmasher/colormaps: https://github.com/1313e/CMasher/tree/master/cmasher/colormaps
+.. _cmasher/colormaps: https://github.com/1313e/CMasher/tree/master/src/cmasher/colormaps

--- a/docs/source/user/usage.rst
+++ b/docs/source/user/usage.rst
@@ -401,4 +401,4 @@ Below are the three different versions of the :ref:`rainforest` colormap one can
 .. _PyPI: https://pypi.org/project/CMasher
 .. _matplotlib: https://github.com/matplotlib/matplotlib
 .. _issue: https://github.com/1313e/CMasher/issues
-.. _cmasher/colormaps: https://github.com/1313e/CMasher/tree/master/cmasher/colormaps
+.. _cmasher/colormaps: https://github.com/1313e/CMasher/tree/master/src/cmasher/colormaps

--- a/joss_paper/paper.md
+++ b/joss_paper/paper.md
@@ -56,7 +56,7 @@ An often cited reason for this (besides the general _"Everyone else uses it."_),
 Although a high perceptual range can be useful in many different cases, it certainly is not useful in all of them and there are ways to achieve this without giving false information.
 This is where *CMasher* comes in.
 
-![Overview of all current colormaps in *CMasher* (v1.2.2).](https://raw.githubusercontent.com/1313e/CMasher/master/cmasher/colormaps/cmap_overview.png)
+![Overview of all current colormaps in *CMasher* (v1.2.2).](https://raw.githubusercontent.com/1313e/CMasher/master/src/cmasher/colormaps/cmap_overview.png)
 
 
 # CMasher


### PR DESCRIPTION
# PR Summary
The `cmasher/colormaps` directory was moved to `src/cmasher/colormaps`. This PR adjusts sources to changes.