### PR TITLE
TST: don't use editable install in CI (again)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,12 +70,12 @@ jobs:
 
     - name: Test package (no coverage)
       if: ${{ !startsWith( matrix.os , 'ubuntu' ) }}
-      run: uv run pytest --color=yes --mpl
+      run: uv run --no-editable pytest --color=yes --mpl
 
     - name: Test package (with coverage)
       if: startsWith( matrix.os , 'ubuntu' )
       run: |
-        uv run coverage run --parallel-mode -m pytest --color=yes --mpl
+        uv run --no-editable coverage run --parallel-mode -m pytest --color=yes --mpl
 
     - name: Upload coverage data
       # only using reports from ubuntu because
@@ -99,7 +99,7 @@ jobs:
     - uses: astral-sh/setup-uv@3b9817b1bf26186f03ab8277bab9b827ea5cc254 # v3.2.0
     - run: | # uv sync --only-group covcheck
         uv venv
-        uv pip install . -r requirements/dev.txt
+        uv pip install -r requirements/dev.txt
 
     - uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
       with:
@@ -108,9 +108,9 @@ jobs:
 
     - name: Check coverage
       run: |
-        uv run coverage combine
-        uv run coverage html --skip-covered --skip-empty
-        uv run coverage report --fail-under=100
+        uv run --no-project coverage combine
+        uv run --no-project coverage html --skip-covered --skip-empty
+        uv run --no-project coverage report --fail-under=100
 
     - name: Upload HTML report if check failed.
       uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3


### PR DESCRIPTION
Fix a silent conflict between #153 and #157: `uv run` will (re)install the project by default, in editable mode.