### PR TITLE
MNT: fix ReadTheDocs builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: '3.13'
+    python: '3.12'
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
fix an invalid configuration I apparently introduced in #152 but didn't notice until now.

```
 Config file validation error

Config validation error in build.tools.python. Expected one of (2.7, 3.6, 3.7, 3.8, 3.9, 3.10, 3.11, 3.12, miniconda3-4.7, miniconda3-3.12-24.1, mambaforge-4.10, mambaforge-22.9, mambaforge-23.11, 3, latest, miniconda-latest, mambaforge-latest), got type str (3.13). Double check the type of the value. A string may be required (e.g. "3.10" instead of 3.10)
```