### PR TITLE
TYP: improve type annotations for `create_cmap_overview` and streamline internal logic to improve type-checkability

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "colorspacious>=1.1.2",
     "matplotlib>=3.5",
     "numpy>=1.21.2",
+    "typing-extensions>=4.4.0 ; python_full_version < '3.12'",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -136,6 +136,7 @@ dependencies = [
     { name = "colorspacious" },
     { name = "matplotlib" },
     { name = "numpy" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
 ]
 
 [package.dev-dependencies]
@@ -165,6 +166,7 @@ requires-dist = [
     { name = "colorspacious", specifier = ">=1.1.2" },
     { name = "matplotlib", specifier = ">=3.5" },
     { name = "numpy", specifier = ">=1.21.2" },
+    { name = "typing-extensions", marker = "python_full_version < '3.12'", specifier = ">=4.4.0" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
originated from #204
This patch has become large enough to warrant its own PR